### PR TITLE
Add --quarter range flag with Q1-Q4 presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ tokens [options]
 | `--yesterday` | Yesterday only |
 | `--week [offset]` | Week (Mon–Sun); `0` = this, `-1` = last, `-2` = two ago, … |
 | `--month [offset]` | Calendar month; same offset semantics as `--week` |
+| `--quarter [val]` | Quarter (3 months); offset (`0` = this, `-1` = last, …) or `Q1`–`Q4` of this year |
 
-`--week` and `--month` cap their upper bound at today, so a current week shows `Mon → today`, not `Mon → Sun`.
+`--week`, `--month`, and `--quarter` cap their upper bound at today, so a current week shows `Mon → today`, not `Mon → Sun`.
 
 ### Grouping
 
@@ -89,6 +90,8 @@ Cached at `~/.cache/tokens/pricing.json` for 7 days. If a refresh fails, the sta
 tokens --week                    # this week, combined
 tokens --week -1                 # last week
 tokens --month -2                # two months ago
+tokens --quarter                 # this quarter
+tokens --quarter Q1              # Q1 of this year
 tokens --last 7 --by-model       # last 7 days, model breakdown
 tokens --project --last 30       # last 30 days, by project
 tokens --project hub             # group by project + filter to "hub"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ RANGE (mutually exclusive, default: all time)
   --yesterday           Yesterday only
   --week [offset]       Week (Mon-Sun); offset 0 = this, -1 = last, -2 = 2 ago...
   --month [offset]      Calendar month; offset 0 = this, -1 = last, -2 = 2 ago...
+  --quarter [val]       Quarter (3 months); offset (0 = this, -1 = last, ...) or Q1-Q4 of this year
 
 GROUPING
   (default)             One row per date, combined; shows Main Model
@@ -99,6 +100,19 @@ const parseArgs = (argv: string[]): Args => {
                 if (next !== undefined && /^-?\d+$/.test(next)) i++
                 if (a === "--week") range.weekOffset = offset
                 else range.monthOffset = offset
+                break
+            }
+            case "--quarter": {
+                const next = argv[i + 1]
+                if (next !== undefined && /^[Qq][1-4]$/.test(next)) {
+                    range.quarter = next.toUpperCase() as "Q1" | "Q2" | "Q3" | "Q4"
+                    i++
+                } else if (next !== undefined && /^-?\d+$/.test(next)) {
+                    range.quarter = Number.parseInt(next, 10)
+                    i++
+                } else {
+                    range.quarter = 0
+                }
                 break
             }
             case "--project": {

--- a/src/ranges.ts
+++ b/src/ranges.ts
@@ -19,12 +19,15 @@ const addDays = (d: Date, n: number): Date => {
 
 const isoDate = (s: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(s)
 
+export type QuarterLabel = "Q1" | "Q2" | "Q3" | "Q4"
+
 export type RangeSpec = {
     last?: number
     from?: string
     to?: string
     weekOffset?: number // 0 = this week, -1 = last, -2 = two weeks ago
     monthOffset?: number
+    quarter?: number | QuarterLabel // number = offset (0 = this), "Q1"-"Q4" = labelled quarter of current year
     today?: boolean
     yesterday?: boolean
 }
@@ -43,12 +46,20 @@ const monthLabel = (offset: number): string => {
     return `${offset} month${offset === 1 ? "" : "s"} ahead`
 }
 
+const quarterOffsetLabel = (offset: number): string => {
+    if (offset === 0) return "this quarter"
+    if (offset === -1) return "last quarter"
+    if (offset < -1) return `${-offset} quarters ago`
+    return `${offset} quarter${offset === 1 ? "" : "s"} ahead`
+}
+
 export const resolveRange = (spec: RangeSpec, now = new Date()): DateRange => {
     const flagsSet = [
         spec.last !== undefined,
         spec.from !== undefined || spec.to !== undefined,
         spec.weekOffset !== undefined,
         spec.monthOffset !== undefined,
+        spec.quarter !== undefined,
         spec.today,
         spec.yesterday,
     ].filter(Boolean).length
@@ -83,6 +94,27 @@ export const resolveRange = (spec: RangeSpec, now = new Date()): DateRange => {
         const end = new Date(m.getFullYear(), m.getMonth() + 1, 0)
         const to = capToToday(ymd(end))
         return { from: ymd(m), to, label: monthLabel(spec.monthOffset) }
+    }
+
+    if (spec.quarter !== undefined) {
+        const currentQ = Math.floor(now.getMonth() / 3)
+        let targetYear: number
+        let targetQ: number
+        let label: string
+        if (typeof spec.quarter === "number") {
+            const totalIdx = now.getFullYear() * 4 + currentQ + spec.quarter
+            targetYear = Math.floor(totalIdx / 4)
+            targetQ = ((totalIdx % 4) + 4) % 4
+            label = quarterOffsetLabel(spec.quarter)
+        } else {
+            targetYear = now.getFullYear()
+            targetQ = Number.parseInt(spec.quarter.slice(1), 10) - 1
+            label = `${spec.quarter} ${targetYear}`
+        }
+        const start = new Date(targetYear, targetQ * 3, 1)
+        const end = new Date(targetYear, targetQ * 3 + 3, 0)
+        const to = capToToday(ymd(end))
+        return { from: ymd(start), to, label }
     }
 
     if (spec.from && !isoDate(spec.from)) throw new Error(`--from must be YYYY-MM-DD, got ${spec.from}`)

--- a/src/specs/tokens.ts
+++ b/src/specs/tokens.ts
@@ -1,6 +1,6 @@
 /// <reference types="@withfig/autocomplete-types" />
 
-const RANGE_FLAGS = ["--last", "--from", "--to", "--today", "--yesterday", "--week", "--month"]
+const RANGE_FLAGS = ["--last", "--from", "--to", "--today", "--yesterday", "--week", "--month", "--quarter"]
 const exclusiveOnRange = (self: string) => RANGE_FLAGS.filter((f) => f !== self)
 
 const offsetSuggestions: Fig.Suggestion[] = [
@@ -9,6 +9,14 @@ const offsetSuggestions: Fig.Suggestion[] = [
     { name: "-2", description: "2 periods ago" },
     { name: "-3", description: "3 periods ago" },
     { name: "-4", description: "4 periods ago" },
+]
+
+const quarterSuggestions: Fig.Suggestion[] = [
+    ...offsetSuggestions,
+    { name: "Q1", description: "Q1 (Jan-Mar) of this year" },
+    { name: "Q2", description: "Q2 (Apr-Jun) of this year" },
+    { name: "Q3", description: "Q3 (Jul-Sep) of this year" },
+    { name: "Q4", description: "Q4 (Oct-Dec) of this year" },
 ]
 
 const completionSpec: Fig.Spec = {
@@ -46,6 +54,12 @@ const completionSpec: Fig.Spec = {
             description: "Calendar month; optional offset (0=this, -1=last, ...)",
             args: { name: "offset", isOptional: true, suggestions: offsetSuggestions },
             exclusiveOn: exclusiveOnRange("--month"),
+        },
+        {
+            name: "--quarter",
+            description: "Quarter (3 months); optional offset (0=this, -1=last, ...) or Q1-Q4",
+            args: { name: "offset", isOptional: true, suggestions: quarterSuggestions },
+            exclusiveOn: exclusiveOnRange("--quarter"),
         },
         {
             name: "--project",


### PR DESCRIPTION
Mirrors --week / --month: numeric offset (0=this, -1=last, ...) with the same upper-bound capping at today. Also accepts Q1-Q4 to pick a labelled quarter of the current year — useful for jumping to a fixed quarter without counting offsets back. The Fig spec exposes both forms.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>